### PR TITLE
#14 Crypto 모듈에서 DataSource 구현체를 RpcClient 인터페이스와 구현체로 개선

### DIFF
--- a/core/crypto/build.gradle.kts
+++ b/core/crypto/build.gradle.kts
@@ -20,7 +20,6 @@ fun getProperty(propertyKey: String): String {
 
 dependencies {
     implementation(projects.core.domain)
-    implementation(projects.core.data)
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)
     implementation(libs.okhttp)

--- a/core/crypto/build.gradle.kts
+++ b/core/crypto/build.gradle.kts
@@ -9,8 +9,14 @@ plugins {
 android {
     namespace = "com.trycatch.aurora.core.crypto"
     buildFeatures.buildConfig = true
-    defaultConfig {
-        buildConfigField("String", "SOLANA_RPC_URL", getProperty("SOLANA_RPC_URL"))
+
+    buildTypes {
+        debug {
+            buildConfigField("String", "SOLANA_RPC_URL", getProperty("SOLANA_TESTNET"))
+        }
+        release {
+            buildConfigField("String", "SOLANA_RPC_URL", getProperty("SOLANA_MAINNET"))
+        }
     }
 }
 

--- a/core/crypto/build.gradle.kts
+++ b/core/crypto/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     alias(libs.plugins.aurora.android.library)
     alias(libs.plugins.aurora.hilt)
@@ -6,6 +8,14 @@ plugins {
 
 android {
     namespace = "com.trycatch.aurora.core.crypto"
+    buildFeatures.buildConfig = true
+    defaultConfig {
+        buildConfigField("String", "SOLANA_RPC_URL", getProperty("SOLANA_RPC_URL"))
+    }
+}
+
+fun getProperty(propertyKey: String): String {
+    return gradleLocalProperties(rootDir, providers).getProperty(propertyKey)
 }
 
 dependencies {

--- a/core/crypto/src/main/kotlin/com/trycatch/crypto/RpcClient.kt
+++ b/core/crypto/src/main/kotlin/com/trycatch/crypto/RpcClient.kt
@@ -20,20 +20,15 @@
  * SOFTWARE.
  */
 
-package com.trycatch.remote.di
+package com.trycatch.crypto
 
-import com.trycatch.data.datasource.SolanaDataSource
-import com.trycatch.remote.datasource.SolanaDataSourceImpl
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import com.trycatch.crypto.model.TokenBalanceCrypto
+import com.trycatch.crypto.model.TokenCrypto
+import com.trycatch.crypto.model.TokenWalletCrypto
 
-@Module
-@InstallIn(SingletonComponent::class)
-internal abstract class DataSourceModule {
-    @Binds
-    @Singleton
-    abstract fun bindSolanaDataSource(solanaDataSourceImpl: SolanaDataSourceImpl): SolanaDataSource
+interface RpcClient {
+    suspend fun getBalance(publicKey: String): Result<Long>
+    suspend fun getTokenWallets(publicKey: String): Result<List<TokenWalletCrypto>>
+    suspend fun getTokenAccountBalance(publicKey: String): Result<TokenBalanceCrypto>
+    suspend fun findByMint(publicKey: String): Result<TokenCrypto>
 }

--- a/core/crypto/src/main/kotlin/com/trycatch/crypto/SolanaRpcClient.kt
+++ b/core/crypto/src/main/kotlin/com/trycatch/crypto/SolanaRpcClient.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024 trycatch
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.trycatch.crypto
+
+import com.metaplex.lib.modules.token.TokenClient
+import com.solana.Solana
+import com.solana.actions.getTokenWallets
+import com.solana.api.getBalance
+import com.solana.api.getTokenAccountBalance
+import com.solana.core.PublicKey
+import com.trycatch.crypto.model.TokenBalanceCrypto
+import com.trycatch.crypto.model.TokenCrypto
+import com.trycatch.crypto.model.TokenWalletCrypto
+import com.trycatch.crypto.model.toCrypto
+import javax.inject.Inject
+
+internal class SolanaRpcClient @Inject constructor(
+    private val solana: Solana,
+    private val tokenClient: TokenClient
+): RpcClient {
+    override suspend fun getBalance(publicKey: String): Result<Long> =
+        solana.api.getBalance(PublicKey(publicKey))
+
+    override suspend fun getTokenWallets(publicKey: String): Result<List<TokenWalletCrypto>> =
+        solana.action.getTokenWallets(PublicKey(publicKey)).map {
+            it.map { wallet ->
+                wallet.toCrypto()
+            }
+        }
+
+    override suspend fun getTokenAccountBalance(publicKey: String): Result<TokenBalanceCrypto> =
+        solana.api.getTokenAccountBalance(PublicKey(publicKey)).map {
+            it.toCrypto()
+        }
+
+    override suspend fun findByMint(publicKey: String): Result<TokenCrypto> =
+        tokenClient.findByMint(PublicKey(publicKey))
+            .map { token ->
+                TokenCrypto(
+                    mint = publicKey,
+                    symbol = token.symbol,
+                    name = token.name,
+                    uri = token.uri,
+                )
+            }
+}

--- a/core/crypto/src/main/kotlin/com/trycatch/crypto/di/RPCClientModule.kt
+++ b/core/crypto/src/main/kotlin/com/trycatch/crypto/di/RPCClientModule.kt
@@ -54,7 +54,7 @@ internal object SolanaModule {
     @Singleton
     fun provideSolanaRPCEndpoint(): RPCEndpoint {
         val network = if (BuildConfig.DEBUG) {
-            Network.devnet
+            Network.testnet
         } else {
             Network.mainnetBeta
         }

--- a/core/crypto/src/main/kotlin/com/trycatch/crypto/di/RPCClientModule.kt
+++ b/core/crypto/src/main/kotlin/com/trycatch/crypto/di/RPCClientModule.kt
@@ -28,6 +28,10 @@ import com.solana.Solana
 import com.solana.networking.HttpNetworkingRouter
 import com.solana.networking.Network
 import com.solana.networking.RPCEndpoint
+import com.trycatch.aurora.core.crypto.BuildConfig
+import com.trycatch.crypto.RpcClient
+import com.trycatch.crypto.SolanaRpcClient
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -37,12 +41,28 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal object NetworkModule {
+internal abstract class ClientModule {
+    @Binds
+    @Singleton
+    abstract fun bindSolanaRpcClient(solanaRpcClient: SolanaRpcClient): RpcClient
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object SolanaModule {
     @Provides
     @Singleton
-    fun provideSolanaEndpoint(): RPCEndpoint {
+    fun provideSolanaRPCEndpoint(): RPCEndpoint {
+        val network = if (BuildConfig.DEBUG) {
+            Network.devnet
+        } else {
+            Network.mainnetBeta
+        }
         return RPCEndpoint.custom(
-            URL("https://soft-dawn-fire.solana-mainnet.quiknode.pro/4163a619a51effd3f6afcab195b0d61f05941be8/"), URL("https://soft-dawn-fire.solana-mainnet.quiknode.pro/4163a619a51effd3f6afcab195b0d61f05941be8/"), Network.mainnetBeta)
+            URL(BuildConfig.SOLANA_RPC_URL),
+            URL(BuildConfig.SOLANA_RPC_URL),
+            network
+        )
     }
 
     @Provides

--- a/core/crypto/src/main/kotlin/com/trycatch/crypto/model/TokenBalanceCrypto.kt
+++ b/core/crypto/src/main/kotlin/com/trycatch/crypto/model/TokenBalanceCrypto.kt
@@ -20,10 +20,23 @@
  * SOFTWARE.
  */
 
-package com.trycatch.data.datasource
+package com.trycatch.crypto.model
 
-import com.trycatch.data.model.QuoteEntity
+import com.solana.api.TokenAmountInfoResponse
+import kotlinx.serialization.Serializable
 
-interface TokenDataSource {
-    suspend fun getQuote(symbol: String): QuoteEntity
-}
+@Serializable
+data class TokenBalanceCrypto(
+    val amount: String?,
+    val decimals: Int,
+    val uiAmount: Double?,
+    val uiAmountString: String
+)
+
+fun TokenAmountInfoResponse.toCrypto() =
+    TokenBalanceCrypto(
+        amount = amount,
+        decimals = decimals,
+        uiAmount = uiAmount,
+        uiAmountString = uiAmountString
+    )

--- a/core/crypto/src/main/kotlin/com/trycatch/crypto/model/TokenCrypto.kt
+++ b/core/crypto/src/main/kotlin/com/trycatch/crypto/model/TokenCrypto.kt
@@ -20,20 +20,22 @@
  * SOFTWARE.
  */
 
-package com.trycatch.crypto.di
+package com.trycatch.crypto.model
 
-import com.trycatch.crypto.SolanaDataSourceImpl
-import com.trycatch.data.datasource.SolanaDataSource
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import com.metaplex.lib.modules.token.models.Token
 
-@Module
-@InstallIn(SingletonComponent::class)
-internal abstract class DataSourceModule {
-    @Binds
-    @Singleton
-    abstract fun bindSolanaDataSource(solanaDataSourceImpl: SolanaDataSourceImpl): SolanaDataSource
-}
+
+data class TokenCrypto(
+    val mint: String,
+    val symbol: String,
+    val name: String,
+    val uri: String,
+)
+
+fun Token.toCrypto(): TokenCrypto =
+    TokenCrypto(
+        mint = mint.toBase58(),
+        symbol = symbol,
+        name = name,
+        uri = uri,
+    )

--- a/core/crypto/src/main/kotlin/com/trycatch/crypto/model/TokenWalletCrypto.kt
+++ b/core/crypto/src/main/kotlin/com/trycatch/crypto/model/TokenWalletCrypto.kt
@@ -22,7 +22,15 @@
 
 package com.trycatch.crypto.model
 
-data class WalletCrypto(
+import com.solana.models.Wallet
+
+data class TokenWalletCrypto(
     val publicKey: String,
-    val privateKey: String
+    val tokenAddress: String,
 )
+
+fun Wallet.toCrypto(): TokenWalletCrypto =
+    TokenWalletCrypto(
+        publicKey = pubkey,
+        tokenAddress = token.address
+    )

--- a/core/data/src/main/kotlin/com/trycatch/data/datasource/SolanaDataSource.kt
+++ b/core/data/src/main/kotlin/com/trycatch/data/datasource/SolanaDataSource.kt
@@ -22,9 +22,11 @@
 
 package com.trycatch.data.datasource
 
+import com.trycatch.data.model.QuoteEntity
 import com.trycatch.data.model.TokenEntity
 
 interface SolanaDataSource {
     suspend fun getBalance(publicKey: String): Result<String>
     suspend fun getTokens(publicKey: String): Result<List<TokenEntity>>
+    suspend fun getTokenQuote(symbol: String): QuoteEntity
 }

--- a/core/data/src/main/kotlin/com/trycatch/data/repository/WalletRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/trycatch/data/repository/WalletRepositoryImpl.kt
@@ -23,9 +23,7 @@
 package com.trycatch.data.repository
 
 import com.trycatch.data.datasource.SolanaDataSource
-import com.trycatch.data.datasource.TokenDataSource
 import com.trycatch.data.datasource.WalletLocalDataSource
-import com.trycatch.data.model.QuoteEntity
 import com.trycatch.data.model.toData
 import com.trycatch.domain.model.Quote
 import com.trycatch.domain.model.Token
@@ -38,8 +36,7 @@ import javax.inject.Inject
 
 class WalletRepositoryImpl @Inject constructor(
     private val walletLocalDataSource: WalletLocalDataSource,
-    private val solanaDataSource: SolanaDataSource,
-    private val tokenDataSource: TokenDataSource
+    private val solanaDataSource: SolanaDataSource
 ): WalletRepository {
     override fun getWallet(): Flow<Wallet> =
         walletLocalDataSource.getWallet()
@@ -64,7 +61,7 @@ class WalletRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getTokenQuote(symbol: String): Flow<Quote> = flow {
-        val quote = tokenDataSource.getQuote(symbol).toDomain()
+        val quote = solanaDataSource.getTokenQuote(symbol).toDomain()
         emit(quote)
     }
 }

--- a/core/remote/build.gradle.kts
+++ b/core/remote/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 android {
     namespace = "com.trycatch.aurora.core.remote"
+    buildFeatures.buildConfig = true
 
     defaultConfig {
         buildConfigField("String", "CMM_API_KEY", getProperty("CMM_API_KEY"))
@@ -20,6 +21,7 @@ fun getProperty(propertyKey: String): String {
 
 dependencies {
     implementation(projects.core.data)
+    implementation(projects.core.crypto)
 
     implementation(libs.retrofit.core)
     implementation(libs.retrofit.kotlin.serialization)

--- a/core/remote/src/main/kotlin/com/trycatch/remote/CMCApiService.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/CMCApiService.kt
@@ -20,11 +20,17 @@
  * SOFTWARE.
  */
 
-package com.trycatch.crypto.model
+package com.trycatch.remote
 
-import kotlinx.serialization.Serializable
+import com.trycatch.remote.model.CMCResponse
+import com.trycatch.remote.model.QuoteWrapperResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
 
-@Serializable
-data class IpfsResponse(
-    val image: String
-)
+interface CMCApiService {
+    @GET("/v1/cryptocurrency/quotes/latest")
+    suspend fun getQuotes(
+        @Query("symbol") symbol: String,
+        @Query("convert") convert: String,
+    ): CMCResponse<QuoteWrapperResponse>
+}

--- a/core/remote/src/main/kotlin/com/trycatch/remote/IPFSApiService.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/IPFSApiService.kt
@@ -24,7 +24,6 @@ package com.trycatch.remote
 
 import com.trycatch.remote.model.IpfsResponse
 import retrofit2.http.GET
-import retrofit2.http.Path
 import retrofit2.http.Url
 
 interface IPFSApiService {

--- a/core/remote/src/main/kotlin/com/trycatch/remote/IPFSApiService.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/IPFSApiService.kt
@@ -22,16 +22,14 @@
 
 package com.trycatch.remote
 
-import com.trycatch.remote.model.CMCResponse
-import com.trycatch.remote.model.QuoteWrapperResponse
+import com.trycatch.remote.model.IpfsResponse
 import retrofit2.http.GET
-import retrofit2.http.Header
-import retrofit2.http.Query
+import retrofit2.http.Path
+import retrofit2.http.Url
 
-interface ApiService {
-    @GET("/v1/cryptocurrency/quotes/latest")
-    suspend fun getQuotes(
-        @Query("symbol") symbol: String,
-        @Query("convert") convert: String,
-    ): CMCResponse<QuoteWrapperResponse>
+interface IPFSApiService {
+    @GET
+    suspend fun fetchIpfsData(
+        @Url url: String
+    ): IpfsResponse
 }

--- a/core/remote/src/main/kotlin/com/trycatch/remote/datasource/SolanaDataSourceImpl.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/datasource/SolanaDataSourceImpl.kt
@@ -69,7 +69,7 @@ class SolanaDataSourceImpl @Inject constructor(
                                 val tokenEntityDeferred = async {
                                     solanaRpcClient.findByMint(wallet.tokenAddress)
                                         .map { token ->
-                                            val ipfs = fetchIpfsData(token.uri)
+                                            val ipfs = getIpfsImage(token.uri)
                                             TokenResponse(
                                                 mint = wallet.tokenAddress,
                                                 symbol = token.symbol,
@@ -104,8 +104,8 @@ class SolanaDataSourceImpl @Inject constructor(
             it.toResponse()
         }
 
-    private suspend fun fetchIpfsData(ipfs: String): String {
-        val data = ipfsApiService.fetchIpfsData(ipfs)
+    private suspend fun getIpfsImage(ipfsUri: String): String {
+        val data = ipfsApiService.fetchIpfsData(ipfsUri)
         return data.image
     }
 

--- a/core/remote/src/main/kotlin/com/trycatch/remote/di/NetworkModule.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/di/NetworkModule.kt
@@ -44,10 +44,12 @@ import javax.inject.Singleton
 internal object NetworkModule {
     @Qualifier
     @Retention(AnnotationRetention.BINARY)
-    annotation class CMC
+    @Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+    annotation class CoinMarketCap
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)
+    @Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
     annotation class IPFS
 
     @Singleton
@@ -56,7 +58,7 @@ internal object NetworkModule {
         ignoreUnknownKeys = true
     }
 
-    @CMC
+    @CoinMarketCap
     @Provides
     @Singleton
     fun provideCMCOkHttpClient(): OkHttpClient {
@@ -106,7 +108,7 @@ internal object NetworkModule {
     @Singleton
     fun provideCMCRetrofit(
         json: Json,
-        @CMC okHttpClient: OkHttpClient
+        @CoinMarketCap okHttpClient: OkHttpClient
     ): CMCApiService {
         return Retrofit.Builder()
             .client(okHttpClient)

--- a/core/remote/src/main/kotlin/com/trycatch/remote/model/IpfsResponse.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/model/IpfsResponse.kt
@@ -20,18 +20,11 @@
  * SOFTWARE.
  */
 
-package com.trycatch.remote
+package com.trycatch.remote.model
 
-import com.trycatch.data.datasource.TokenDataSource
-import com.trycatch.data.model.QuoteEntity
-import javax.inject.Inject
+import kotlinx.serialization.Serializable
 
-class TokenDataSourceImpl @Inject constructor(
-    private val apiService: ApiService
-): TokenDataSource {
-    override suspend fun getQuote(symbol: String): QuoteEntity {
-        val response = apiService.getQuotes(symbol, "USD")
-        val quote = response.data[symbol]?.quote ?: throw Exception("Quote not found")
-        return quote.toEntity()
-    }
-}
+@Serializable
+data class IpfsResponse(
+    val image: String
+)

--- a/core/remote/src/main/kotlin/com/trycatch/remote/model/TokenBalanceResponse.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/model/TokenBalanceResponse.kt
@@ -20,27 +20,23 @@
  * SOFTWARE.
  */
 
-package com.trycatch.crypto.model
+package com.trycatch.remote.model
 
-import com.trycatch.data.model.TokenEntity
+import com.trycatch.crypto.model.TokenBalanceCrypto
+import kotlinx.serialization.Serializable
 
-data class TokenResponse(
-    val mint: String = "",
-    val symbol: String = "",
-    val name: String = "",
-    val image: String = "",
-    val amount: String = "",
-    val uiAmountString: String = "",
-    val decimals: Int = 0,
-) {
-    fun toEntity(): TokenEntity =
-        TokenEntity(
-            mint = mint,
-            symbol = symbol,
-            name = name,
-            image = image,
-            amount = amount,
-            uiAmountString = uiAmountString,
-            decimals = decimals,
-        )
-}
+@Serializable
+data class TokenBalanceResponse(
+    val amount: String?,
+    val decimals: Int,
+    val uiAmount: Double?,
+    val uiAmountString: String
+)
+
+fun TokenBalanceCrypto.toResponse() =
+    TokenBalanceResponse(
+        amount = amount,
+        decimals = decimals,
+        uiAmount = uiAmount,
+        uiAmountString = uiAmountString
+    )

--- a/core/remote/src/main/kotlin/com/trycatch/remote/model/TokenResponse.kt
+++ b/core/remote/src/main/kotlin/com/trycatch/remote/model/TokenResponse.kt
@@ -20,20 +20,27 @@
  * SOFTWARE.
  */
 
-package com.trycatch.remote.di
+package com.trycatch.remote.model
 
-import com.trycatch.data.datasource.SolanaDataSource
-import com.trycatch.remote.datasource.SolanaDataSourceImpl
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import com.trycatch.data.model.TokenEntity
 
-@Module
-@InstallIn(SingletonComponent::class)
-internal abstract class DataSourceModule {
-    @Binds
-    @Singleton
-    abstract fun bindSolanaDataSource(solanaDataSourceImpl: SolanaDataSourceImpl): SolanaDataSource
+data class TokenResponse(
+    val mint: String = "",
+    val symbol: String = "",
+    val name: String = "",
+    val image: String = "",
+    val amount: String = "",
+    val uiAmountString: String = "",
+    val decimals: Int = 0,
+) {
+    fun toEntity(): TokenEntity =
+        TokenEntity(
+            mint = mint,
+            symbol = symbol,
+            name = name,
+            image = image,
+            amount = amount,
+            uiAmountString = uiAmountString,
+            decimals = decimals,
+        )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-
-android.defaults.buildfeatures.buildconfig=true


### PR DESCRIPTION
## 작업 내용
- crypto 모듈에서 RpcClient 인터페이스와 구현체를 정의
- remote 모듈에서 이를 의존하고 활용하도록 변경

### 의존성 그래프
| 수정 전 | 수정 후 |
| --- | --- |
| ![수정 전](https://github.com/user-attachments/assets/af3273d7-b248-4d6f-b45d-51fd8afe08af) | ![수정 후](https://github.com/user-attachments/assets/4a233b3d-efba-4098-80aa-274ff898da05) |

## 관련 이슈
- Close: #14 
